### PR TITLE
Add parameter to specify marker/apriltag size

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ roslaunch tams_apriltags april_cube_demo.launch
 ```
 
 See `apriltag_marker.xacro` for the actual Xacro macro and its parameters.
-You can specify marker name, tag family, tag ID, and the marker size.
-At the moment, the macro requires a parent object and generates the
-corresponding fixed joint.
+You can specify marker name, tag family, tag ID, and the marker size by using parameters
+"size" and "apriltag_size". In case of specifying both size parameters, the "size" parameter 
+will be recalculated. At the moment, the macro requires a parent object and generates 
+the corresponding fixed joint.
+
 
 Note the use of Python expressions (introduced in ROS Jade)
 to rewrite the tag family string and to ensure leading zeros for the tag ID.

--- a/urdf/apriltag_marker.xacro
+++ b/urdf/apriltag_marker.xacro
@@ -6,22 +6,45 @@
        tag-family, ID, and size. The marker is modeled as a simple
        box with outer xy diameter as specified, and z 1mm thickness.
        The marker is centered and can be added to other xacro/urdf
-       models.
+       models. 
+       The parameter "include_borders" is used to indicate 
+       whether the one bit wide white borders are included in the 
+       size specification. If "include_borders" is set to true,
+       the actual size of the apriltag will be:
+       8/10*size in case of 36h11
+       6/8 *size in case of 16h5
+       This is due to the usage of the white border in the 
+       apriltag detection algorithm, even though its size
+       is not specified.
 
        2019.10.10 - fix Collada rotation, ooops
        2019.05.22 - switch to textured Collada meshes, needs Jade or higher
        2014.11.24 - created
-
+       2021.11.10 - added include_borders parameter 
        (C) 2014 fnh, hendrich@informatik.uni-hamburg.de
 
        Usage:
        <xacro:apriltag_marker namespace="doro/" name="apriltag13" parent="base_link" 
-              family="36_11" ID="00013" size="0.05">
+              family="36h11" ID="00013" size="0.05" include_borders="false">
          <origin xyz="0.2 0.3 05" rpy="0 0 3.14" />
        </xacro:apriltag_marker>
    -->
 
-  <xacro:macro name="apriltag_marker" params="namespace name parent family ID size *origin" >
+  <xacro:macro name="apriltag_marker" params="namespace name parent family ID size include_borders:=true *origin" >
+    
+    <xacro:if value="${include_borders == False}">
+      <xacro:if value="${family == '36h11'}">
+        <xacro:property name="mesh_size" value="${size/8*10}" />
+      </xacro:if>
+      <xacro:if value="${family == '16h5'}">
+        <xacro:property name="mesh_size" value="${size/6*8}" />
+      </xacro:if>
+    </xacro:if>
+    
+    <xacro:if value="${include_borders == True}">
+      <xacro:property name="mesh_size" value="${size}" />
+    </xacro:if>
+    
     <link name="${namespace}${name}">
       <inertial>
         <mass value="0.001" />
@@ -31,14 +54,14 @@
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <box size="${size} ${size} 0.001" />
+          <box size="${mesh_size} ${mesh_size} 0.001" />
         </geometry>
       </collision>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
           <!-- use Python str to convert family name and to generate leading zeros -->
-          <mesh filename="package://tams_apriltags/meshes/tag${str(family).replace( 'h', '_' )}_${str(ID).zfill(5)}.dae" scale="${10*size} ${10*size} 1"/>
+          <mesh filename="package://tams_apriltags/meshes/tag${str(family).replace( 'h', '_' )}_${str(ID).zfill(5)}.dae" scale="${10*mesh_size} ${10*mesh_size} 1"/>
         </geometry>
       </visual>
     </link>

--- a/urdf/apriltag_marker.xacro
+++ b/urdf/apriltag_marker.xacro
@@ -33,19 +33,19 @@
        </xacro:apriltag_marker>
    -->
 
-  <xacro:macro name="apriltag_marker" params="namespace name parent family ID size apriltag_size:=-1 *origin" >
+  <xacro:macro name="apriltag_marker" params="namespace name parent family ID size:=0 apriltag_size:=0 *origin" >
     
     
-    <xacro:if value="${apriltag_size == -1}">
-      <xacro:property name="mesh_size" value="${apriltag_size}" />
+    <xacro:if value="${apriltag_size == 0}">
+      <xacro:property name="mesh_size" value="${size}" />
     </xacro:if>
     
-    <xacro:if value="${apriltag_size != -1}">
+    <xacro:if value="${apriltag_size != 0}">
       <xacro:if value="${family == '36h11'}">
-        <xacro:property name="mesh_size" value="${size/8*10}" />
+        <xacro:property name="mesh_size" value="${apriltag_size/8*10}" />
       </xacro:if>
       <xacro:if value="${family == '16h5'}">
-        <xacro:property name="mesh_size" value="${size/6*8}" />
+        <xacro:property name="mesh_size" value="${apriltag_size/6*8}" />
       </xacro:if>
     </xacro:if>
     

--- a/urdf/apriltag_marker.xacro
+++ b/urdf/apriltag_marker.xacro
@@ -4,7 +4,7 @@
 
   <!-- ROS xacro/urdf model of one apriltag marker with given
        tag-family, ID, and size of the mesh. Optionally, apriltag_size can be 
-       specified to calculate from it the size of the mesh. In this case the 
+       specified to calculate from it the size of the mesh. In this case, the 
        parameter "size" will be ignored. The marker is modeled as 
        a simple box with outer xy diameter as specified, and z 1mm thickness.
        The marker is centered and can be added to other xacro/urdf
@@ -26,20 +26,32 @@
        Usage:
        size - size of the mesh 
        apriltag_size - size of the apriltag. If this parameter is set, the size 
-       of the mesh will be re-calculated
+       of the mesh will be re-calculated as mentioned above
+
        <xacro:apriltag_marker namespace="doro/" name="apriltag13" parent="base_link" 
-              family="36h11" ID="00013" size="0.05" include_borders="false">
+              family="36h11" ID="00013" size="0.33" >
+         <origin xyz="0.2 0.3 05" rpy="0 0 3.14" />
+
+       <xacro:apriltag_marker namespace="doro/" name="apriltag14" parent="base_link" 
+              family="36h11" ID="00014" apriltag_size="0.5">
+         <origin xyz="0.2 0.3 05" rpy="0 0 3.14" />
+       </xacro:apriltag_marker>
+
+       The following definition does not make much sense and will produce the same result
+       as the one above with ID=00014, because the mesh is predefined and the size of the 
+       border will not be recalculated.
+       <xacro:apriltag_marker namespace="doro/" name="apriltag14" parent="base_link" 
+              family="36h11" ID="00014" size="0.33" apriltag_size="0.5">
          <origin xyz="0.2 0.3 05" rpy="0 0 3.14" />
        </xacro:apriltag_marker>
    -->
 
   <xacro:macro name="apriltag_marker" params="namespace name parent family ID size:=0 apriltag_size:=0 *origin" >
     
-    
+    <!-- Check in which way the size was specified -->
     <xacro:if value="${apriltag_size == 0}">
       <xacro:property name="mesh_size" value="${size}" />
     </xacro:if>
-    
     <xacro:if value="${apriltag_size != 0}">
       <xacro:if value="${family == '36h11'}">
         <xacro:property name="mesh_size" value="${apriltag_size/8*10}" />
@@ -49,7 +61,6 @@
       </xacro:if>
     </xacro:if>
     
-
     
     <link name="${namespace}${name}">
       <inertial>

--- a/urdf/apriltag_marker.xacro
+++ b/urdf/apriltag_marker.xacro
@@ -3,19 +3,19 @@
        name="apriltag_marker">
 
   <!-- ROS xacro/urdf model of one apriltag marker with given
-       tag-family, ID, and size. The marker is modeled as a simple
-       box with outer xy diameter as specified, and z 1mm thickness.
+       tag-family, ID, and size of the mesh. Optionally, apriltag_size can be 
+       specified to calculate from it the size of the mesh. In this case the 
+       parameter "size" will be ignored. The marker is modeled as 
+       a simple box with outer xy diameter as specified, and z 1mm thickness.
        The marker is centered and can be added to other xacro/urdf
        models. 
-       The parameter "include_borders" is used to indicate 
-       whether the one bit wide white borders are included in the 
-       size specification. If "include_borders" is set to true,
+       The mesh of the model contains one bit wide white borders. Therefore,
        the actual size of the apriltag will be:
        8/10*size in case of 36h11
        6/8 *size in case of 16h5
        This is due to the usage of the white border in the 
        apriltag detection algorithm, even though its size
-       is not specified.
+       does not have a convention.
 
        2019.10.10 - fix Collada rotation, ooops
        2019.05.22 - switch to textured Collada meshes, needs Jade or higher
@@ -24,15 +24,23 @@
        (C) 2014 fnh, hendrich@informatik.uni-hamburg.de
 
        Usage:
+       size - size of the mesh 
+       apriltag_size - size of the apriltag. If this parameter is set, the size 
+       of the mesh will be re-calculated
        <xacro:apriltag_marker namespace="doro/" name="apriltag13" parent="base_link" 
               family="36h11" ID="00013" size="0.05" include_borders="false">
          <origin xyz="0.2 0.3 05" rpy="0 0 3.14" />
        </xacro:apriltag_marker>
    -->
 
-  <xacro:macro name="apriltag_marker" params="namespace name parent family ID size include_borders:=true *origin" >
+  <xacro:macro name="apriltag_marker" params="namespace name parent family ID size apriltag_size:=-1 *origin" >
     
-    <xacro:if value="${include_borders == False}">
+    
+    <xacro:if value="${apriltag_size == -1}">
+      <xacro:property name="mesh_size" value="${apriltag_size}" />
+    </xacro:if>
+    
+    <xacro:if value="${apriltag_size != -1}">
       <xacro:if value="${family == '36h11'}">
         <xacro:property name="mesh_size" value="${size/8*10}" />
       </xacro:if>
@@ -41,9 +49,7 @@
       </xacro:if>
     </xacro:if>
     
-    <xacro:if value="${include_borders == True}">
-      <xacro:property name="mesh_size" value="${size}" />
-    </xacro:if>
+
     
     <link name="${namespace}${name}">
       <inertial>

--- a/urdf/apriltag_marker.xacro
+++ b/urdf/apriltag_marker.xacro
@@ -33,7 +33,7 @@
          <origin xyz="0.2 0.3 05" rpy="0 0 3.14" />
 
        <xacro:apriltag_marker namespace="doro/" name="apriltag14" parent="base_link" 
-              family="36h11" ID="00014" apriltag_size="0.5">
+              family="36h11" ID="00014" apriltag_size="0.05">
          <origin xyz="0.2 0.3 05" rpy="0 0 3.14" />
        </xacro:apriltag_marker>
 
@@ -41,7 +41,7 @@
        as the one above with ID=00014, because the mesh is predefined and the size of the 
        border will not be recalculated.
        <xacro:apriltag_marker namespace="doro/" name="apriltag14" parent="base_link" 
-              family="36h11" ID="00014" size="0.33" apriltag_size="0.5">
+              family="36h11" ID="00014" size="0.33" apriltag_size="0.05">
          <origin xyz="0.2 0.3 05" rpy="0 0 3.14" />
        </xacro:apriltag_marker>
    -->


### PR DESCRIPTION
With the parameter ""include_borders":=false" it is possible to specify
whether the desired size is the size of the whole marker including borders, or
just of the apriltag marker. In the latter case the size of the resulting
marker will be bigger due to the mandatory white borders around the
apriltag